### PR TITLE
issue #185: upgrade versions and add containerd option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The Kubernates module is used to deploy the EKS cluster in Amazon. Also creates 
 - `Spot or on_demand workers` - node-labels=kubernetes.io/lifecycle=normal for on_demand node and node-labels=kubernetes.io/lifecycle=spot for spot node. Your make use it for [Node affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node)
 - `Add arns for additional admins` - We set current user to add as admin EKS cluster. Your make add additional admins arn's to variables admin_arns in variables.tf or module parameters in project
 
+- `Use containerd as CRI instead of docker` - Starting from 1.21 EKS started to support another type of [Container Runtime Interface](https://kubernetes.io/docs/setup/production-environment/container-runtimes/). You can set variable `container_runtime` to `docker` or `containerd`.
+
 ## Usage
 ```
 module "kubernetes" {

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ data "aws_ami" "eks_gpu_worker" {
 
 module "eks" {
   source          = "terraform-aws-modules/eks/aws"
-  version         = "17.18.0"
+  version         = "17.23.0"
   cluster_version = var.cluster_version
   cluster_name    = var.cluster_name
   kubeconfig_name = var.cluster_name
@@ -36,7 +36,7 @@ module "eks" {
 
 
   # NOTE:
-  #  enable cloudwatch logging 
+  #  enable cloudwatch logging
   cluster_enabled_log_types     = var.cloudwatch_logging_enabled ? var.cloudwatch_cluster_log_types : []
   cluster_log_retention_in_days = var.cloudwatch_logging_enabled ? var.cloudwatch_cluster_log_retention_days : 90
 
@@ -56,7 +56,7 @@ module "eks" {
 
   workers_group_defaults = {
     additional_userdata  = "sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm && sudo systemctl enable amazon-ssm-agent && sudo systemctl start amazon-ssm-agent"
-    bootstrap_extra_args = "--docker-config-json ${local.docker_config_json}"
+    bootstrap_extra_args = (var.container_runtime == "containerd") ? "--container-runtime containerd" : "--docker-config-json ${local.docker_config_json}"
   }
 
   # Note:

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "cluster_name" {
 variable "cluster_version" {
   type        = string
   description = "EKS cluster version"
-  default     = "1.19"
+  default     = "1.21"
 }
 
 variable "vpc_id" {
@@ -28,6 +28,15 @@ variable "vpc_id" {
   description = "An ID of the existing AWS VPC"
 }
 
+variable "container_runtime" {
+  type        = string
+  default     = "docker"
+  description = "Type of container runtime interface. Allowed values: docker/containerd"
+  validation {
+    condition     = can(regex("^(docker|containerd)$", var.container_runtime))
+    error_message = "Must be docker or containerd."
+  }
+}
 
 variable "availability_zones" {
   description = "Availability zones for project"


### PR DESCRIPTION
1. Upgraded and tested (argocd, agrocd-with-applications) K8s version from 1.19 -> 1.21
2. Upgraded and tested (argocd, agrocd-with-applications) aws-eks-terrafrom module from 17.18.0 -> 17.23.0
3. Added variable to change container runtime (docker or containerd). Also tested previous 2 steps with containerd. Left docker as default runtime.
4. Changed README


Is is ok to leave docker as default container runtime? @RustamGimadiev  @GrigorovskyA  